### PR TITLE
remove unnecessary seconds conversion for date

### DIFF
--- a/bm2evernote.py
+++ b/bm2evernote.py
@@ -9,7 +9,7 @@ class Bookmark():
         self.title = title
         self.url = url
         self.tag = '<tag>' + tag + '</tag>'
-        self.date = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime(float(long(date) / 1000000)))
+        self.date = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime(float(date)))
         self.content = '''<a href="%(url)s">%(title)s</a>''' % {'title': self.title, 'url': self.url}
 
     def printAsEnex(self):


### PR DESCRIPTION
Not sure if it's a unix vs windows thing, but the add_date was not parsing correctly when I imported to Evernote (reverting to epoch for all bookmarks).

I'm on a mac and it works really well without the seconds conversion for me.
