### PR TITLE
Remove date conversion and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 bookmarks2evernote
 ==================
 
-A simple command line tool to transform bookmarks exported from Google Chrome and Google Bookmarks into Evernote as individual notes using EN's enex format.
-If the html file you are using as input uses H3 as folder name, this are translated into Evernote tags. For this to work correctly, you must ensure when exporting Google Chrome Bookmarks that all the folders are located at the end of your bookmark's list.
+A simple command line tool to transform bookmarks exported from Google Chrome and Google Bookmarks into Evernote as _individual_ notes using EN's enex format.
+If the html file you are using as input uses H3 as folder name, this are translated into Evernote tags.
+For this to work correctly, you may have to ensure when exporting Google Chrome Bookmarks that all the folders are located at the end of your bookmark's list.
 
 It also indentifies duplicated bookmarks in the same HTML file. Google Bookmarks export feature duplicates all bookmarks with more than one tag.
 
@@ -14,4 +15,8 @@ Requisites:
 
 Usage:
 ------
-It takes a single parameter, the name of the input html file. The ouput file will have the same name but with an enex extension.
+It takes a single parameter, the name of the input html file. 
+
+E.g. `python bm2evernote.py YOUR_BOOKMARKS_EXPORT_FILE.html`
+
+The output file will have the same name as the input but with an enex extension.

--- a/bm2evernote.py
+++ b/bm2evernote.py
@@ -9,7 +9,7 @@ class Bookmark():
         self.title = title
         self.url = url
         self.tag = '<tag>' + tag + '</tag>'
-        self.date = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime(float(long(date) / 1000000)))
+        self.date = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime(float(date)))
         self.content = '''<a href="%(url)s">%(title)s</a>''' % {'title': self.title, 'url': self.url}
 
     def printAsEnex(self):


### PR DESCRIPTION
Not sure if it's a unix vs windows thing, but the add_date was not parsing correctly when I imported to Evernote (reverting to epoch for all bookmarks).

I'm on a mac and it works really well without the seconds conversion for me.

Also, I updated the readme to include the very handy explicit instructions in the bottom comment of your blogpost (at time of writing).

Thanks for writing the post - I would not have found it otherwise!